### PR TITLE
Chore: update .gitignore to include binary files and environment vari…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
-internal/config/
+# Binary files (executables in root directory)
+/main
+/oauth
+/scoreboard
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# But allow .env.example
+!.env.example


### PR DESCRIPTION
…able configurations

Added entries to .gitignore for various binary files, including executables and test outputs, as well as environment variable files to streamline the development process and prevent sensitive information from being tracked. This enhances project maintainability and security.