### PR TITLE
refactor: Rename custom validation function for consistency

### DIFF
--- a/internal/validator.go
+++ b/internal/validator.go
@@ -1,8 +1,9 @@
 package internal
 
 import (
-	"github.com/go-playground/validator/v10"
 	"regexp"
+
+	"github.com/go-playground/validator/v10"
 )
 
 func NewValidator() *validator.Validate {
@@ -17,10 +18,10 @@ func ValidateStruct(v *validator.Validate, s interface{}) error {
 	return nil
 }
 func RegisterCustomValidations(validate *validator.Validate) {
-	validate.RegisterValidation("alphanumerspaceunderhyphen", alphanumerspaceunderhyphen)
+	validate.RegisterValidation("Alphanumerspaceunderhyphen", Alphanumerspaceunderhyphen)
 }
 
-func alphanumerspaceunderhyphen(fl validator.FieldLevel) bool {
+func Alphanumerspaceunderhyphen(fl validator.FieldLevel) bool {
 	str := fl.Field().String()
 	if str == "" {
 		return false


### PR DESCRIPTION
Updated the custom validation function name from `alphanumerspaceunderhyphen` to `Alphanumerspaceunderhyphen` to follow Go naming conventions and improve code readability. This change enhances the clarity of the validation logic within the internal validator package.